### PR TITLE
Make SQL Statements Uppercase

### DIFF
--- a/code/server/app/src/main/java/server/infrastructure/param/auth/UserSession.java
+++ b/code/server/app/src/main/java/server/infrastructure/param/auth/UserSession.java
@@ -29,7 +29,7 @@ public class UserSession{
             var res = cache.validate(token);
             if(res!=null)return res;
         }
-        try (var stmt = conn.namedPreparedStatement("select * from sessions left join users on sessions.user_id=users.id where sessions.token=:token")) {
+        try (var stmt = conn.namedPreparedStatement("SELECT * FROM sessions LEFT JOIN users ON sessions.user_id=users.id WHERE sessions.token=:token")) {
             stmt.setString(":token", token);
             try(var result = stmt.executeQuery()){
                 if (result == null || !result.next())
@@ -57,7 +57,7 @@ public class UserSession{
             var res = cache.validate(token);
             if(res!=null)return res;
         }
-        try (var stmt = conn.namedPreparedStatement("select * from sessions left join users on sessions.user_id=users.id where sessions.token=:token")) {
+        try (var stmt = conn.namedPreparedStatement("SELECT * FROM sessions LEFT JOIN users ON sessions.user_id=users.id WHERE sessions.token=:token")) {
             stmt.setString(":token", token);
             try(var result = stmt.executeQuery()){
                 if (result == null || !result.next()) return null;

--- a/code/server/app/src/main/java/server/infrastructure/root/api/AdminAPI.java
+++ b/code/server/app/src/main/java/server/infrastructure/root/api/AdminAPI.java
@@ -119,7 +119,7 @@ public class AdminAPI {
 
     @Route("/delete_other_account/<email>")
     public static void delete_other_account(@FromRequest(RequireAdmin.class) UserSession auth, RwTransaction trans, @Path String email) throws SQLException, BadRequest {
-        try(var stmt = trans.namedPreparedStatement("delete from users where email=:email")){
+        try(var stmt = trans.namedPreparedStatement("DELETE FROM users WHERE email=:email")){
             stmt.setString(":email", email);
             if(stmt.executeUpdate() != 1)
                 throw new BadRequest("Account with the specified email does not exist");
@@ -130,7 +130,7 @@ public class AdminAPI {
     @Route("/set_account_admin/<admin>/<email>")
     public static void set_account_admin(@FromRequest(RequireAdmin.class) UserSession auth, RwTransaction trans, @Path boolean admin, @Path String email) throws SQLException, BadRequest {
         long id;
-        try(var stmt = trans.namedPreparedStatement("update users set admin=:admin where email=:email returning id")){
+        try(var stmt = trans.namedPreparedStatement("UPDATE users SET admin=:admin WHERE email=:email RETURNING id")){
             stmt.setString(":email", email);
             stmt.setBoolean(":admin", admin);
             var rs = stmt.executeQuery();
@@ -138,7 +138,7 @@ public class AdminAPI {
                 throw new BadRequest("Account with the specified email does not exist");
             id = rs.getLong("id");
         }
-        try(var stmt = trans.namedPreparedStatement("delete from sessions where user_id=:id")){
+        try(var stmt = trans.namedPreparedStatement("DELETE FROM sessions WHERE user_id=:id")){
             stmt.setLong(":id", id);
             stmt.execute();
         }

--- a/code/server/app/src/main/java/server/infrastructure/root/api/EventAPI.java
+++ b/code/server/app/src/main/java/server/infrastructure/root/api/EventAPI.java
@@ -25,7 +25,7 @@ public class EventAPI {
     @Route
     public static long create_event(@FromRequest(RequireOrganizer.class) UserSession session, RwTransaction trans) throws SQLException {
         long result;
-        try(var stmt = trans.namedPreparedStatement("insert into events values(null, :owner_id, '', '', null, null, '', '', null, null, null, true, null, null, null) returning id")){
+        try(var stmt = trans.namedPreparedStatement("INSERT INTO events values(null, :owner_id, '', '', null, null, '', '', null, null, null, true, null, null, null) RETURNING id")){
             stmt.setLong(":owner_id", session.user_id);
             result = stmt.executeQuery().getLong("id");
         }
@@ -70,7 +70,7 @@ public class EventAPI {
     @Route("/get_event/<id>")
     public static @Json AllEvent get_event(@FromRequest(OptionalAuth.class) UserSession session, RoTransaction trans, @Path long id) throws SQLException, BadRequest {
         Event event;
-        try(var stmt = trans.namedPreparedStatement("select * from events where (id=:id AND draft=false) OR (id=:id AND owner_id=:owner_id)")){
+        try(var stmt = trans.namedPreparedStatement("SELECT * FROM events WHERE (id=:id AND draft=false) OR (id=:id AND owner_id=:owner_id)")){
             stmt.setLong(":id", id);
             if(session!=null)
                 stmt.setLong(":owner_id", session.user_id);
@@ -83,7 +83,7 @@ public class EventAPI {
         }
 
         List<EventTag> tags;
-        try(var stmt = trans.namedPreparedStatement("select * from event_tags where event_id=:event_id")){
+        try(var stmt = trans.namedPreparedStatement("SELECT * FROM event_tags WHERE event_id=:event_id")){
             stmt.setLong(":event_id", event.id);
             tags = SqlSerde.sqlList(stmt.executeQuery(), EventTag.class);
         }
@@ -251,7 +251,7 @@ public class EventAPI {
     @Route("/delete_event/<id>")
     public static void delete_event(@FromRequest(RequireOrganizer.class)UserSession session, RwTransaction trans, @Path long id, DynamicMediaHandler media) throws SQLException, BadRequest {
         long picture;
-        try(var stmt = trans.namedPreparedStatement("delete from events where id=:id AND owner_id=:owner_id returning picture")){
+        try(var stmt = trans.namedPreparedStatement("DELETE FROM events WHERE id=:id AND owner_id=:owner_id RETURNING picture")){
             stmt.setLong(":id", id);
             stmt.setLong(":owner_id", session.user_id);
             var rs = stmt.executeQuery();
@@ -270,7 +270,7 @@ public class EventAPI {
 
     @Route("/add_event_tag/<id>/<tag>")
     public static void add_event_tag(@FromRequest(RequireOrganizer.class)UserSession session, RwTransaction trans, @Path long id, @Path String tag) throws SQLException, BadRequest {
-        try(var stmt = trans.namedPreparedStatement("insert into event_tags values(:tag, :id)")){
+        try(var stmt = trans.namedPreparedStatement("INSERT INTO event_tags values(:tag, :id)")){
             stmt.setLong(":id", id);
             stmt.setString(":tag", tag);
             try{
@@ -285,7 +285,7 @@ public class EventAPI {
 
     @Route("/delete_event_tag/<id>/<tag>")
     public static void delete_event_tag(@FromRequest(RequireOrganizer.class)UserSession session, RwTransaction trans, @Path long id, @Path String tag) throws SQLException, BadRequest {
-        try(var stmt = trans.namedPreparedStatement("delete from event_tags where tag=:tag AND event_id=:event_id")){
+        try(var stmt = trans.namedPreparedStatement("DELETE FROM event_tags WHERE tag=:tag AND event_id=:event_id")){
             stmt.setLong(":id", id);
             stmt.setString(":tag", tag);
             if(stmt.executeUpdate()!=1)
@@ -296,7 +296,7 @@ public class EventAPI {
 
     @Route("/set_draft/<id>/<draft>")
     public static void set_draft(@FromRequest(RequireOrganizer.class)UserSession session, RwTransaction trans, @Path long id, @Path boolean draft) throws SQLException, BadRequest {
-        try(var stmt = trans.namedPreparedStatement("update events set draft=:draft where id=:id AND owner_id=:owner_id")){
+        try(var stmt = trans.namedPreparedStatement("UPDATE events SET draft=:draft WHERE id=:id AND owner_id=:owner_id")){
             stmt.setLong(":id", id);
             stmt.setLong(":owner_id", session.user_id);
             stmt.setBoolean(":draft", draft);
@@ -316,13 +316,13 @@ public class EventAPI {
         var media_id = handler.add(data);
         long old_media = 0;
         try{
-            try(var stmt = trans.namedPreparedStatement("select picture from events where id=:id AND owner_id=:owner_id")){
+            try(var stmt = trans.namedPreparedStatement("SELECT picture FROM events WHERE id=:id AND owner_id=:owner_id")){
                 stmt.setLong(":id", id);
                 stmt.setLong(":owner_id", session.user_id);
                 old_media = stmt.executeQuery().getLong(1);
             }
 
-            try(var stmt = trans.namedPreparedStatement("update events set picture=:picture where id=:id AND owner_id=:owner_id")){
+            try(var stmt = trans.namedPreparedStatement("UPDATE events SET picture=:picture WHERE id=:id AND owner_id=:owner_id")){
                 stmt.setLong(":id", id);
                 stmt.setLong(":owner_id", session.user_id);
                 stmt.setLong(":picture", media_id);

--- a/code/server/app/src/main/java/server/infrastructure/root/api/OrganizerAPI.java
+++ b/code/server/app/src/main/java/server/infrastructure/root/api/OrganizerAPI.java
@@ -16,18 +16,18 @@ public class OrganizerAPI {
 
     @Route
     public static void convert_to_organizer_account(@FromRequest(RequireSession.class)UserSession auth, RwTransaction trans) throws SQLException, BadRequest {
-        try(var stmt = trans.namedPreparedStatement("select organizer from users where id=:user_id")){
+        try(var stmt = trans.namedPreparedStatement("SELECT organizer FROM users WHERE id=:user_id")){
             stmt.setLong(":user_id", auth.user_id);
             if(stmt.executeQuery().getBoolean("organizer"))
                 throw new BadRequest("Account already an organizer");
         }
-        try(var stmt = trans.namedPreparedStatement("update users set organizer=true where id=:user_id")){
+        try(var stmt = trans.namedPreparedStatement("UPDATE users SET organizer=true WHERE id=:user_id")){
             stmt.setLong(":user_id", auth.user_id);
             if(stmt.executeUpdate()!=1)
                 throw new BadRequest("Failed to set user organizer");
         }
         // this is a stupid hack to make caching function
-        try(var stmt = trans.namedPreparedStatement("update sessions set id=id where user_id=:id")){
+        try(var stmt = trans.namedPreparedStatement("UPDATE sessions SET id=id WHERE user_id=:id")){
             stmt.setLong(":id", auth.user_id);
             stmt.execute();
         }

--- a/code/server/app/src/main/java/server/infrastructure/root/api/PaymentAPI.java
+++ b/code/server/app/src/main/java/server/infrastructure/root/api/PaymentAPI.java
@@ -61,7 +61,7 @@ public class PaymentAPI {
             throw new BadRequest("Cannot purchase account organizer upgrade, account is already organizer");
 
         List<Ticket> tickets;
-        try(var stmt = trans.namedPreparedStatement("select * from users join json_each(:tickets) on users.id=json_each.value")){
+        try(var stmt = trans.namedPreparedStatement("SELECT * FROM users JOIN json_each(:tickets) ON users.id=json_each.value")){
             stmt.setString(":tickets", ticket_ids.toJSONString());
             tickets = SqlSerde.sqlList(stmt.executeQuery(), Ticket.class);
         }

--- a/code/server/app/src/main/java/server/infrastructure/root/api/SearchAPI.java
+++ b/code/server/app/src/main/java/server/infrastructure/root/api/SearchAPI.java
@@ -152,7 +152,7 @@ public class SearchAPI {
         long_map.put(":limit", limit);
 
         List<EventAPI.Event> events_partial;
-        try(var stmt = trans.namedPreparedStatement("select * from events " + clauses)){
+        try(var stmt = trans.namedPreparedStatement("SELECT * FROM events " + clauses)){
             for(var es : str_map.entrySet()){
                 stmt.setString(es.getKey(), es.getValue());
             }
@@ -170,7 +170,7 @@ public class SearchAPI {
             events.add(new EventAPI.AllEvent(event, new ArrayList<>()));
         }
 
-        try(var stmt = trans.namedPreparedStatement("select id, tag, category from events left join event_tags on id=event_id " + clauses)){
+        try(var stmt = trans.namedPreparedStatement("SELECT id, tag, category FROM events LEFT JOIN event_tags ON id=event_id " + clauses)){
             for(var es : str_map.entrySet()){
                 stmt.setString(es.getKey(), es.getValue());
             }


### PR DESCRIPTION
Hello friends, Parker is very smelly and uses mixed case / lowercase SQL statements. This is incorrect and is resolved by this pull request.

Only namedPreparedStatements were changed; partial SQL statements are unaffected.